### PR TITLE
Hotfix/13 - AbstractEc2::setRegion() writes to $_defaultRegion instead of $_region

### DIFF
--- a/library/ZendService/Amazon/Ec2/AbstractEc2.php
+++ b/library/ZendService/Amazon/Ec2/AbstractEc2.php
@@ -101,7 +101,7 @@ abstract class AbstractEc2 extends Amazon\AbstractAmazon
     public static function setRegion($region)
     {
         if(in_array(strtolower($region), self::$_validEc2Regions, true)) {
-            self::$_Region = $region;
+            self::$_region = $region;
         } else {
             throw new Exception\InvalidArgumentException('Invalid Amazon Ec2 Region');
         }


### PR DESCRIPTION
fix #13
AbstractEc2::setRegion() writes to $_defaultRegion. But $_defaultRegion is only used in the Constructor if you dont provide an region. In all other cases $_region is used.

So if you have an instance of eg ZendService\Amazon\Ec2\Instance and use setRegion its not used at all.

(Wanted to add unit test for it, but i failed as _getRegion is protected and my phpunit skills are limited.)
