### PR TITLE
Offer class incorrectly assumed the merchant id always existed.

### DIFF
--- a/library/ZendService/Amazon/Offer.php
+++ b/library/ZendService/Amazon/Offer.php
@@ -75,29 +75,33 @@ class Offer
     {
         $xpath = new DOMXPath($dom->ownerDocument);
         $xpath->registerNamespace('az', 'http://webservices.amazon.com/AWSECommerceService/' . Amazon::getVersion());
-        $merchantId = $xpath->query('./az:Merchant/az:MerchantId/text()', $dom);
-        if ($merchantId->length == 1) {
-            $this->MerchantId = (string) $merchantId->item(0)->data;
+
+        $map = array(
+            'MerchantId'     => './az:Merchant/az:MerchantId/text()',
+            'MerchantName'   => './az:Merchant/az:Name/text()',
+            'GlancePage'     => './az:Merchant/az:GlancePage/text()',
+            'Condition'      => './az:OfferAttributes/az:Condition/text()',
+            'OfferListingId' => './az:OfferListing/az:OfferListingId/text()',
+            'Price'          => './az:OfferListing/az:Price/az:Amount/text()',
+            'CurrencyCode'   => './az:OfferListing/az:Price/az:CurrencyCode/text()',
+            'Availability'   => './az:OfferListing/az:Availability/text()',
+            'IsEligibleForSuperSaverShipping' => './az:OfferListing/az:IsEligibleForSuperSaverShipping/text()',
+        );
+
+        foreach ($map as $param_name => $xquery) {
+            $query_result = $xpath->query($xquery, $dom);
+            if ($query_result->length <= 0) {
+                continue;
+            }
+            $text = $query_result->item(0);
+            if (!$text instanceof DOMText) {
+                continue;
+            }
+            $this->$param_name = (string) $text->data;
         }
-        $name = $xpath->query('./az:Merchant/az:Name/text()', $dom);
-        if ($name->length == 1) {
-          $this->MerchantName = (string) $name->item(0)->data;
-        }
-        $this->GlancePage = (string) $xpath->query('./az:Merchant/az:GlancePage/text()', $dom)->item(0)->data;
-        $this->Condition = (string) $xpath->query('./az:OfferAttributes/az:Condition/text()', $dom)->item(0)->data;
-        $this->OfferListingId = (string) $xpath->query('./az:OfferListing/az:OfferListingId/text()', $dom)->item(0)->data;
-        $Price = $xpath->query('./az:OfferListing/az:Price/az:Amount', $dom);
-        if ($Price->length == 1) {
-            $this->Price = (int) $xpath->query('./az:OfferListing/az:Price/az:Amount/text()', $dom)->item(0)->data;
-            $this->CurrencyCode = (string) $xpath->query('./az:OfferListing/az:Price/az:CurrencyCode/text()', $dom)->item(0)->data;
-        }
-        $availability = $xpath->query('./az:OfferListing/az:Availability/text()', $dom)->item(0);
-        if($availability instanceof DOMText) {
-            $this->Availability = (string) $availability->data;
-        }
-        $result = $xpath->query('./az:OfferListing/az:IsEligibleForSuperSaverShipping/text()', $dom);
-        if ($result->length >= 1) {
-            $this->IsEligibleForSuperSaverShipping = (bool) $result->item(0)->data;
+
+        if (isset($this->IsEligibleForSuperSaverShipping)) {
+            $this->IsEligibleForSuperSaverShipping = (bool) $this->IsEligibleForSuperSaverShipping;
         }
     }
 }


### PR DESCRIPTION
We were having a problem using this because the Amazon responses wouldn't always have a merchant id, which would cause this notice:

> Notice: Trying to get property of non-object in /path/vendor/zendframework/zendservice-amazon/library/ZendService/Amazon/Offer.php on line 78

Offer response from Amazon:

```
[0] => ZendService\Amazon\Offer Object
                        (
                            [MerchantId] => 
                            [MerchantName] => 
                            [GlancePage] => 
                            [Condition] => New
                            [OfferListingId] => imHEHzRFLdt73yrifok3lj1%2BZmJGDaw2l7Fg8itPlHmFvTaV6QYiyxZtiR7fJk39zVduT5puzBnzoEe3ag009ieGvSciYKiIy8r%2F%2BTcfqComwqtz1k44CjqjQtAo1aBhWCcmqmu9pQozm6UK3kjszXRJeLAFLLp8
                            [Price] => 5672
                            [CurrencyCode] => USD
                            [Availability] => Usually ships in 1-2 business days
                            [IsEligibleForSuperSaverShipping] => 
                        )
```
