### PR TITLE
Fixed constructor of S3 Adapter: third argument must be of instance HttpClient

### DIFF
--- a/library/ZendService/Amazon/S3/S3.php
+++ b/library/ZendService/Amazon/S3/S3.php
@@ -95,9 +95,9 @@ class S3 extends \ZendService\Amazon\AbstractAmazon
      * @param string $secretKey
      * @param string $region
      */
-    public function __construct($accessKey = null, $secretKey = null)
+    public function __construct($accessKey = null, $secretKey = null, HttpClient $httpClient = null)
     {
-        parent::__construct($accessKey, $secretKey);
+        parent::__construct($accessKey, $secretKey, $httpClient);
 
         $this->setEndpoint('http://'.self::S3_ENDPOINT);
     }


### PR DESCRIPTION
To initialize a connection to S3 is this implementation a region is not used
and will fail because the abstract class `AbstractAmazon` expects a
HttpClient instance as third argument. 

To define the region of a bucket use

    $service = new \ZendService\Amazon\S3\S3("**_", "**_*");
    $service->createBucket("yourbucket", "EU");
