### PR TITLE
added missing use statement

### DIFF
--- a/library/ZendService/Amazon/AbstractAmazon.php
+++ b/library/ZendService/Amazon/AbstractAmazon.php
@@ -54,6 +54,11 @@ abstract class AbstractAmazon
      * @var string attribute for preserving the date object
      */
     const DATE_PRESERVE_KEY = 'preserve';
+    
+    /**
+     * @var string Format to use for Date header
+     */
+    const AMAZON_DATE_FORMAT='D, d M Y H:i:s \G\M\T';
 
     /**
      * Constructor
@@ -157,9 +162,9 @@ abstract class AbstractAmazon
     }
 
     /**
-     * Method to get the request date - returns gmdate(DATE_RFC1123, time())
+     * Method to get the request date - returns date in GMT to self::AMAZON_DATE_FORMAT format
      *
-     *     "Tue, 15 May 2012 15:18:31 +0000"
+     *     "Tue, 15 May 2012 15:18:31 GMT"
      *
      * Unless setRequestDate was set (as when testing the service)
      *
@@ -175,7 +180,9 @@ abstract class AbstractAmazon
                 $this->requestDate = null;
             }
         }
-        return $date->format(DateTime::RFC1123);
+        
+        $date->setTimezone(new \DateTimeZone('GMT'));
+        return $date->format(self::AMAZON_DATE_FORMAT);
     }
 
     /**

--- a/library/ZendService/Amazon/S3/S3.php
+++ b/library/ZendService/Amazon/S3/S3.php
@@ -17,6 +17,7 @@ use Zend\Http\Response\Stream as StreamResponse;
 use ZendService\Amazon;
 use ZendService\Amazon\S3\Exception;
 use Zend\Uri;
+use Zend\Http\Client as HttpClient;
 
 /**
  * Amazon S3 PHP connection class


### PR DESCRIPTION
The constructors accepts an Zend\Http\Client object as defined in the 3rd argument of its signature:

`public function __construct($accessKey = null, $secretKey = null, HttpClient $httpClient = null)`

However the typehint is trying to match in the current namespace rather than the correct Zend\Http\Client namespace.

Added use statement to fix.
