### PR TITLE
Bugfix: Show front cover instead of back cover

### DIFF
--- a/library/ZendService/Amazon/Item.php
+++ b/library/ZendService/Amazon/Item.php
@@ -138,7 +138,7 @@ class Item
         }
 
         foreach (array('SmallImage', 'MediumImage', 'LargeImage') as $im) {
-            $result = $xpath->query("./az:ImageSets/az:ImageSet[position() = 1]/az:$im", $dom);
+            $result = $xpath->query("./az:ImageSets/az:ImageSet[@Category='primary']/az:$im", $dom);
             if ($result->length == 1) {
                 $this->$im = new Image($result->item(0));
             }

--- a/library/ZendService/Amazon/ResultSet.php
+++ b/library/ZendService/Amazon/ResultSet.php
@@ -154,4 +154,13 @@ class ResultSet implements \SeekableIterator
     {
         return null !== $this->_results && $this->_currentIndex < $this->_results->length;
     }
+
+    /**
+     * Returns whether the Amazon API returned an error.
+     * @return bool whether an error occurred
+     */
+    public function hasError()
+    {
+        return ($this->_xpath->evaluate('name(/*)') == 'ItemSearchErrorResponse');
+    }
 }


### PR DESCRIPTION
Some books seem to have extended imagesets containing back covers. The Zend AmazonService included the back cover for many books instead of the front cover.