### PR TITLE
Updated QA toolchain

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,38 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('library')
+    ->in('tests')
+    ->notPath('_files');
+$config = Symfony\CS\Config\Config::create();
+$config->level(null);
+$config->fixers(
+    array(
+        'braces',
+        'duplicate_semicolon',
+        'elseif',
+        'empty_return',
+        'encoding',
+        'eof_ending',
+        'function_call_space',
+        'function_declaration',
+        'indentation',
+        'join_function',
+        'line_after_namespace',
+        'linefeed',
+        'lowercase_keywords',
+        'parenthesis',
+        'multiple_use',
+        'method_argument_space',
+        'object_operator',
+        'php_closing_tag',
+        'remove_lines_between_uses',
+        'short_tag',
+        'standardize_not_equal',
+        'trailing_spaces',
+        'unused_use',
+        'visibility',
+        'whitespacy_lines',
+    )
+);
+$config->finder($finder);
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,37 @@
+sudo: false
+
 language: php
 
-php:
-  - 5.3
-  - 5.4
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env:
+        - EXECUTE_CS_CHECK=true
+    - php: 7
+    - php: hhvm
+  allow_failures:
+    - php: 7
+    - php: hhvm
 
 before_install:
+ - phpenv config-rm xdebug.ini
+ - composer self-update
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - composer install --dev
- - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+
+install:
+  - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
- - phpunit -c ./tests/
- - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
+ - ./vendor/bin/phpunit -c ./tests/
+ - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,17 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      env:
+        - DISABLE_XDEBUG=true
     - php: 5.4
+      env:
+        - DISABLE_XDEBUG=true
     - php: 5.5
+      env:
+        - DISABLE_XDEBUG=true
     - php: 5.6
       env:
+        - DISABLE_XDEBUG=true
         - EXECUTE_CS_CHECK=true
     - php: 7
     - php: hhvm
@@ -22,7 +29,7 @@ matrix:
     - php: hhvm
 
 before_install:
- - phpenv config-rm xdebug.ini
+ - if [[ $DISABLE_XDEBUG == 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
  - composer self-update
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
             "ZendService\\Amazon\\": "library/"
         }
     },
+    "autoload-dev": {
+        "psr-0": {
+            "ZendServiceTest\\Amazon\\": "tests/ZendServiceTest/Amazon/"
+        }
+    },
     "repositories": [
         {
             "type": "composer",
@@ -32,6 +37,8 @@
         "zendframework/zendxml": "~1.0-dev"
     },
     "require-dev": {
+        "fabpot/php-cs-fixer": "~1.7.0",
+        "phpunit/phpunit": "~4.0",
         "zendframework/zend-i18n": "~2.0"
     },
     "suggest": {

--- a/library/ZendService/Amazon/AbstractAmazon.php
+++ b/library/ZendService/Amazon/AbstractAmazon.php
@@ -107,7 +107,6 @@ abstract class AbstractAmazon
      */
     public function setRequestDate(DateTime $date = null, $preserve = null)
     {
-
         if ($date instanceof DateTime && !is_null($preserve)) {
             $date->{self::DATE_PRESERVE_KEY} = (boolean) $preserve;
         }

--- a/library/ZendService/Amazon/Amazon.php
+++ b/library/ZendService/Amazon/Amazon.php
@@ -14,7 +14,6 @@ use DOMDocument;
 use DOMXPath;
 use Zend\Crypt\Hmac;
 use ZendRest\Client\RestClient;
-use ZendService\Amazon\Exception;
 
 /**
  * @category   Zend
@@ -82,8 +81,9 @@ class Amazon
         $this->appId = (string) $appId;
         $this->_secretKey = $secretKey;
 
-        if (!is_null($version))
+        if (!is_null($version)) {
             self::setVersion($version);
+        }
 
         $countryCode = (string) $countryCode;
         if (!isset($this->_baseUriList[$countryCode])) {
@@ -173,7 +173,7 @@ class Amazon
      */
     public function getRestClient()
     {
-        if($this->_rest === null) {
+        if ($this->_rest === null) {
             $this->_rest = new RestClient();
         }
         return $this->_rest;
@@ -219,7 +219,7 @@ class Amazon
 
         $options = array_merge($defaultOptions, $options);
 
-        if($this->_secretKey !== null) {
+        if ($this->_secretKey !== null) {
             $options['Timestamp'] = gmdate("Y-m-d\TH:i:s\Z");
             ksort($options);
             $options['Signature'] = self::computeSignature($this->_baseUri, $this->_secretKey, $options);
@@ -255,7 +255,7 @@ class Amazon
     {
         ksort($options);
         $params = array();
-        foreach($options AS $k => $v) {
+        foreach ($options as $k => $v) {
             $params[] = $k."=".rawurlencode($v);
         }
 
@@ -282,7 +282,7 @@ class Amazon
             $code = $xpath->query('//az:Error/az:Code/text()')->item(0)->data;
             $message = $xpath->query('//az:Error/az:Message/text()')->item(0)->data;
 
-            switch($code) {
+            switch ($code) {
                 case 'AWS.ECommerceService.NoExactMatches':
                     break;
                 default:

--- a/library/ZendService/Amazon/Authentication/S3.php
+++ b/library/ZendService/Amazon/Authentication/S3.php
@@ -76,13 +76,11 @@ class S3 extends AbstractAuthentication
         $sig_str .= '/'.parse_url($path, PHP_URL_PATH);
         if (strpos($path, '?location') !== false) {
             $sig_str .= '?location';
-        } else
-            if (strpos($path, '?acl') !== false) {
-                $sig_str .= '?acl';
-            } else
-                if (strpos($path, '?torrent') !== false) {
-                    $sig_str .= '?torrent';
-                }
+        } elseif (strpos($path, '?acl') !== false) {
+            $sig_str .= '?acl';
+        } elseif (strpos($path, '?torrent') !== false) {
+            $sig_str .= '?torrent';
+        }
 
         $signature = Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), Hmac::OUTPUT_BINARY);
         $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . base64_encode($signature);

--- a/library/ZendService/Amazon/Authentication/V1.php
+++ b/library/ZendService/Amazon/Authentication/V1.php
@@ -40,7 +40,7 @@ class V1 extends AbstractAuthentication
         $parameters['AWSAccessKeyId']   = $this->_accessKey;
         $parameters['SignatureVersion'] = $this->_signatureVersion;
         $parameters['Version']          = $this->_apiVersion;
-        if(!isset($parameters['Timestamp'])) {
+        if (!isset($parameters['Timestamp'])) {
             $parameters['Timestamp']    = gmdate('Y-m-d\TH:i:s\Z', time()+10);
         }
 
@@ -76,7 +76,7 @@ class V1 extends AbstractAuthentication
         uksort($parameters, 'strcasecmp');
         unset($parameters['Signature']);
 
-        foreach($parameters as $key => $value) {
+        foreach ($parameters as $key => $value) {
             $data .= $key . $value;
         }
 

--- a/library/ZendService/Amazon/Authentication/V2.php
+++ b/library/ZendService/Amazon/Authentication/V2.php
@@ -47,7 +47,7 @@ class V2 extends AbstractAuthentication
         $parameters['SignatureVersion'] = $this->_signatureVersion;
         $parameters['Version']          = $this->_apiVersion;
         $parameters['SignatureMethod']  = $this->_signatureMethod;
-        if(!isset($parameters['Timestamp'])) {
+        if (!isset($parameters['Timestamp'])) {
             $parameters['Timestamp']    = gmdate('Y-m-d\TH:i:s\Z', time()+10);
         }
 
@@ -105,7 +105,7 @@ class V2 extends AbstractAuthentication
         unset($parameters['Signature']);
 
         $arrData = array();
-        foreach($parameters as $key => $value) {
+        foreach ($parameters as $key => $value) {
             $arrData[] = $key . '=' . str_replace('%7E', '~', rawurlencode($value));
         }
 

--- a/library/ZendService/Amazon/Ec2/AbstractEc2.php
+++ b/library/ZendService/Amazon/Ec2/AbstractEc2.php
@@ -12,7 +12,6 @@ namespace ZendService\Amazon\Ec2;
 
 use DOMXPath;
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 use Zend\Crypt\Hmac;
 use Zend\Http\Client as HttpClient;
 
@@ -138,7 +137,6 @@ abstract class AbstractEc2 extends Amazon\AbstractAmazon
             $request->setParameterPost($params);
 
             $httpResponse = $request->send();
-
         } catch (\Zend\Http\Client\Exception\ExceptionInterface $zhce) {
             $message = 'Error in request to AWS service: ' . $zhce->getMessage();
             throw new Exception\RuntimeException($message, $zhce->getCode(), $zhce);

--- a/library/ZendService/Amazon/Ec2/AvailabilityZones.php
+++ b/library/ZendService/Amazon/Ec2/AvailabilityZones.php
@@ -11,8 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
-
 /**
  * An Amazon EC2 interface to query which Availability Zones your account has access to.
  *
@@ -34,11 +32,11 @@ class AvailabilityZones extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeAvailabilityZones';
 
-        if(is_array($zoneName) && !empty($zoneName)) {
-            foreach($zoneName as $k=>$name) {
+        if (is_array($zoneName) && !empty($zoneName)) {
+            foreach ($zoneName as $k=>$name) {
                 $params['ZoneName.' . ($k+1)] = $name;
             }
-        } elseif($zoneName) {
+        } elseif ($zoneName) {
             $params['ZoneName.1'] = $zoneName;
         }
 

--- a/library/ZendService/Amazon/Ec2/CloudWatch.php
+++ b/library/ZendService/Amazon/Ec2/CloudWatch.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * An Amazon EC2 interface that allows yout to run, terminate, reboot and describe Amazon
@@ -234,37 +233,45 @@ class CloudWatch extends AbstractEc2
             throw new Exception\InvalidArgumentException('Invalid Metric Type: ' . $options['MeasureName']);
         }
 
-        if(!isset($options['Statistics'])) {
+        if (!isset($options['Statistics'])) {
             $options['Statistics'][] = 'Average';
-        } elseif(!is_array($options['Statistics'])) {
+        } elseif (!is_array($options['Statistics'])) {
             $options['Statistics'][] = $options['Statistics'];
         }
 
-        foreach($options['Statistics'] as $k=>$s) {
-            if(!in_array($s, $this->_validStatistics, true)) continue;
+        foreach ($options['Statistics'] as $k=>$s) {
+            if (!in_array($s, $this->_validStatistics, true)) {
+                continue;
+            }
             $options['Statistics.member.' . ($k+1)] = $s;
             $_usedStatistics[] = $s;
         }
         unset($options['Statistics']);
 
-        if(isset($options['StartTime'])) {
-            if(!is_numeric($options['StartTime'])) $options['StartTime'] = strtotime($options['StartTime']);
+        if (isset($options['StartTime'])) {
+            if (!is_numeric($options['StartTime'])) {
+                $options['StartTime'] = strtotime($options['StartTime']);
+            }
             $options['StartTime'] = gmdate('c', $options['StartTime']);
         } else {
             $options['StartTime'] = gmdate('c', strtotime('-1 hour'));
         }
 
-        if(isset($options['EndTime'])) {
-            if(!is_numeric($options['EndTime'])) $options['EndTime'] = strtotime($options['EndTime']);
+        if (isset($options['EndTime'])) {
+            if (!is_numeric($options['EndTime'])) {
+                $options['EndTime'] = strtotime($options['EndTime']);
+            }
             $options['EndTime'] = gmdate('c', $options['EndTime']);
         } else {
             $options['EndTime'] = gmdate('c');
         }
 
-        if(isset($options['Dimensions'])) {
+        if (isset($options['Dimensions'])) {
             $x = 1;
-            foreach($options['Dimensions'] as $dimKey=>$dimVal) {
-                if(!in_array($dimKey, $this->_validDimensionsKeys, true)) continue;
+            foreach ($options['Dimensions'] as $dimKey=>$dimVal) {
+                if (!in_array($dimKey, $this->_validDimensionsKeys, true)) {
+                    continue;
+                }
                 $options['Dimensions.member.' . $x . '.Name'] = $dimKey;
                 $options['Dimensions.member.' . $x . '.Value'] = $dimVal;
                 $x++;
@@ -283,13 +290,13 @@ class CloudWatch extends AbstractEc2
 
         $return = array();
         $return['label'] = $xpath->evaluate('string(//ec2:GetMetricStatisticsResult/ec2:Label/text())');
-        foreach ( $nodes as $node ) {
+        foreach ($nodes as $node) {
             $item = array();
 
             $item['Timestamp'] = $xpath->evaluate('string(ec2:Timestamp/text())', $node);
             $item['Unit'] = $xpath->evaluate('string(ec2:Unit/text())', $node);
             $item['Samples'] = $xpath->evaluate('string(ec2:Samples/text())', $node);
-            foreach($_usedStatistics as $us) {
+            foreach ($_usedStatistics as $us) {
                 $item[$us] = $xpath->evaluate('string(ec2:' . $us . '/text())', $node);
             }
 
@@ -298,7 +305,6 @@ class CloudWatch extends AbstractEc2
         }
 
         return $return;
-
     }
 
     /**
@@ -324,7 +330,7 @@ class CloudWatch extends AbstractEc2
         $nodes = $xpath->query('//ec2:ListMetricsResult/ec2:Metrics/ec2:member');
 
         $return = array();
-        foreach ( $nodes as $node ) {
+        foreach ($nodes as $node) {
             $item = array();
 
             $item['MeasureName'] = $xpath->evaluate('string(ec2:MeasureName/text())', $node);

--- a/library/ZendService/Amazon/Ec2/Ebs.php
+++ b/library/ZendService/Amazon/Ec2/Ebs.php
@@ -11,8 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
-
 /**
  * An Amazon EC2 interface to create, describe, attach, detach and delete Elastic Block
  * Storage Volumes and Snapshots.
@@ -96,11 +94,11 @@ class Ebs extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeVolumes';
 
-        if(is_array($volumeId) && !empty($volumeId)) {
-            foreach($volumeId as $k=>$name) {
+        if (is_array($volumeId) && !empty($volumeId)) {
+            foreach ($volumeId as $k=>$name) {
                 $params['VolumeId.' . ($k+1)] = $name;
             }
-        } elseif($volumeId) {
+        } elseif ($volumeId) {
             $params['VolumeId.1'] = $volumeId;
         }
 
@@ -119,7 +117,7 @@ class Ebs extends AbstractEc2
             $item['createTime'] = $xpath->evaluate('string(ec2:createTime/text())', $node);
 
             $attachmentSet = $xpath->query('ec2:attachmentSet/ec2:item', $node);
-            if($attachmentSet->length == 1) {
+            if ($attachmentSet->length == 1) {
                 $_as = $attachmentSet->item(0);
                 $as = array();
                 $as['volumeId'] = $xpath->evaluate('string(ec2:volumeId/text())', $_as);
@@ -146,8 +144,8 @@ class Ebs extends AbstractEc2
         $volumes = $this->describeVolume();
 
         $return = array();
-        foreach($volumes as $vol) {
-            if(isset($vol['attachmentSet']) && $vol['attachmentSet']['instanceId'] == $instanceId) {
+        foreach ($volumes as $vol) {
+            if (isset($vol['attachmentSet']) && $vol['attachmentSet']['instanceId'] == $instanceId) {
                 $return[] = $vol;
             }
         }
@@ -280,11 +278,11 @@ class Ebs extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeSnapshots';
 
-        if(is_array($snapshotId) && !empty($snapshotId)) {
-            foreach($snapshotId as $k=>$name) {
+        if (is_array($snapshotId) && !empty($snapshotId)) {
+            foreach ($snapshotId as $k=>$name) {
                 $params['SnapshotId.' . ($k+1)] = $name;
             }
-        } elseif($snapshotId) {
+        } elseif ($snapshotId) {
             $params['SnapshotId.1'] = $snapshotId;
         }
 

--- a/library/ZendService/Amazon/Ec2/Ec2.php
+++ b/library/ZendService/Amazon/Ec2/Ec2.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * Amazon Ec2 Interface to allow easy creation of the Ec2 Components
@@ -33,7 +32,7 @@ class Ec2
      */
     public static function factory($section, $key = null, $secretKey = null)
     {
-        switch(strtolower($section)) {
+        switch (strtolower($section)) {
             case 'keypair':
                 $class = '\ZendService\Amazon\Ec2\Keypair';
                 break;

--- a/library/ZendService/Amazon/Ec2/ElasticIp.php
+++ b/library/ZendService/Amazon/Ec2/ElasticIp.php
@@ -11,8 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
-
 /**
  * An Amazon EC2 interface to allocate, associate, describe and release Elastic IP address
  * from your account.
@@ -52,11 +50,11 @@ class ElasticIp extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeAddresses';
 
-        if(is_array($publicIp) && !empty($publicIp)) {
-            foreach($publicIp as $k=>$name) {
+        if (is_array($publicIp) && !empty($publicIp)) {
+            foreach ($publicIp as $k=>$name) {
                 $params['PublicIp.' . ($k+1)] = $name;
             }
-        } elseif($publicIp) {
+        } elseif ($publicIp) {
             $params['PublicIp.1'] = $publicIp;
         }
 
@@ -140,5 +138,4 @@ class ElasticIp extends AbstractEc2
 
         return ($return === "true");
     }
-
 }

--- a/library/ZendService/Amazon/Ec2/Image.php
+++ b/library/ZendService/Amazon/Ec2/Image.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * An Amazon EC2 interface to register, describe and deregister Amamzon Machine Instances (AMI)
@@ -93,27 +92,27 @@ class Image extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeImages';
 
-        if(is_array($imageId) && !empty($imageId)) {
-            foreach($imageId as $k=>$name) {
+        if (is_array($imageId) && !empty($imageId)) {
+            foreach ($imageId as $k=>$name) {
                 $params['ImageId.' . ($k+1)] = $name;
             }
-        } elseif($imageId) {
+        } elseif ($imageId) {
             $params['ImageId.1'] = $imageId;
         }
 
-        if(is_array($owner) && !empty($owner)) {
-            foreach($owner as $k=>$name) {
+        if (is_array($owner) && !empty($owner)) {
+            foreach ($owner as $k=>$name) {
                 $params['Owner.' . ($k+1)] = $name;
             }
-        } elseif($owner) {
+        } elseif ($owner) {
             $params['Owner.1'] = $owner;
         }
 
-        if(is_array($executableBy) && !empty($executableBy)) {
-            foreach($executableBy as $k=>$name) {
+        if (is_array($executableBy) && !empty($executableBy)) {
+            foreach ($executableBy as $k=>$name) {
                 $params['ExecutableBy.' . ($k+1)] = $name;
             }
-        } elseif($executableBy) {
+        } elseif ($executableBy) {
             $params['ExecutableBy.1'] = $executableBy;
         }
 
@@ -203,26 +202,26 @@ class Image extends AbstractEc2
         $parmas['ImageId'] = $imageId;
         $params['Attribute'] = $attribute;
 
-        switch($attribute) {
+        switch ($attribute) {
             case 'launchPermission':
                 // break left out
             case 'launchpermission':
                 $params['Attribute'] = 'launchPermission';
                 $params['OperationType'] = $operationType;
 
-                if(is_array($userId) && !empty($userId)) {
-                    foreach($userId as $k=>$name) {
+                if (is_array($userId) && !empty($userId)) {
+                    foreach ($userId as $k=>$name) {
                         $params['UserId.' . ($k+1)] = $name;
                     }
-                } elseif($userId) {
+                } elseif ($userId) {
                     $params['UserId.1'] = $userId;
                 }
 
-                if(is_array($userGroup) && !empty($userGroup)) {
-                    foreach($userGroup as $k=>$name) {
+                if (is_array($userGroup) && !empty($userGroup)) {
+                    foreach ($userGroup as $k=>$name) {
                         $params['UserGroup.' . ($k+1)] = $name;
                     }
-                } elseif($userGroup) {
+                } elseif ($userGroup) {
                     $params['UserGroup.1'] = $userGroup;
                 }
 
@@ -268,30 +267,29 @@ class Image extends AbstractEc2
         $return['imageId'] = $xpath->evaluate('string(//ec2:imageId/text())');
 
         // check for launchPermission
-        if($attribute == 'launchPermission') {
+        if ($attribute == 'launchPermission') {
             $lPnodes = $xpath->query('//ec2:launchPermission/ec2:item');
 
-            if($lPnodes->length > 0) {
+            if ($lPnodes->length > 0) {
                 $return['launchPermission'] = array();
-                foreach($lPnodes as $node) {
+                foreach ($lPnodes as $node) {
                     $return['launchPermission'][] = $xpath->evaluate('string(ec2:userId/text())', $node);
                 }
             }
         }
 
         // check for product codes
-        if($attribute == 'productCodes') {
+        if ($attribute == 'productCodes') {
             $pCnodes = $xpath->query('//ec2:productCodes/ec2:item');
-            if($pCnodes->length > 0) {
+            if ($pCnodes->length > 0) {
                 $return['productCodes'] = array();
-                foreach($pCnodes as $node) {
+                foreach ($pCnodes as $node) {
                     $return['productCodes'][] = $xpath->evaluate('string(ec2:productCode/text())', $node);
                 }
             }
         }
 
         return $return;
-
     }
 
     /**

--- a/library/ZendService/Amazon/Ec2/Instance.php
+++ b/library/ZendService/Amazon/Ec2/Instance.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * An Amazon EC2 interface that allows yout to run, terminate, reboot and describe Amazon
@@ -107,7 +106,7 @@ class Instance extends AbstractEc2
         // set / override the defualt optoins if they are not passed into the array;
         $options = array_merge($_defaultOptions, $options);
 
-        if(!isset($options['imageId'])) {
+        if (!isset($options['imageId'])) {
             throw new Exception\InvalidArgumentException('No Image Id Provided');
         }
 
@@ -118,44 +117,44 @@ class Instance extends AbstractEc2
         $params['MinCount'] = $options['minCount'];
         $params['MaxCount'] = $options['maxCount'];
 
-        if(isset($options['keyName'])) {
+        if (isset($options['keyName'])) {
             $params['KeyName'] = $options['keyName'];
         }
 
-        if(is_array($options['securityGroup']) && !empty($options['securityGroup'])) {
-            foreach($options['securityGroup'] as $k=>$name) {
+        if (is_array($options['securityGroup']) && !empty($options['securityGroup'])) {
+            foreach ($options['securityGroup'] as $k=>$name) {
                 $params['SecurityGroup.' . ($k+1)] = $name;
             }
-        } elseif(isset($options['securityGroup'])) {
+        } elseif (isset($options['securityGroup'])) {
             $params['SecurityGroup.1'] = $options['securityGroup'];
         }
 
-        if(isset($options['userData'])) {
+        if (isset($options['userData'])) {
             $params['UserData'] = base64_encode($options['userData']);
         }
 
-        if(isset($options['instanceType'])) {
+        if (isset($options['instanceType'])) {
             $params['InstanceType'] = $options['instanceType'];
         }
 
-        if(isset($options['placement'])) {
+        if (isset($options['placement'])) {
             $params['Placement.AvailabilityZone'] = $options['placement'];
         }
 
-        if(isset($options['kernelId'])) {
+        if (isset($options['kernelId'])) {
             $params['KernelId'] = $options['kernelId'];
         }
 
-        if(isset($options['ramdiskId'])) {
+        if (isset($options['ramdiskId'])) {
             $params['RamdiskId'] = $options['ramdiskId'];
         }
 
-        if(isset($options['blockDeviceVirtualName']) && isset($options['blockDeviceName'])) {
+        if (isset($options['blockDeviceVirtualName']) && isset($options['blockDeviceName'])) {
             $params['BlockDeviceMapping.n.VirtualName'] = $options['blockDeviceVirtualName'];
             $params['BlockDeviceMapping.n.DeviceName'] = $options['blockDeviceName'];
         }
 
-        if(isset($options['monitor']) && $options['monitor'] === true) {
+        if (isset($options['monitor']) && $options['monitor'] === true) {
             $params['Monitoring.Enabled'] = true;
         }
 
@@ -168,14 +167,14 @@ class Instance extends AbstractEc2
         $return['ownerId'] = $xpath->evaluate('string(//ec2:ownerId/text())');
 
         $gs = $xpath->query('//ec2:groupSet/ec2:item');
-        foreach($gs as $gs_node) {
+        foreach ($gs as $gs_node) {
             $return['groupSet'][] = $xpath->evaluate('string(ec2:groupId/text())', $gs_node);
             unset($gs_node);
         }
         unset($gs);
 
         $is = $xpath->query('//ec2:instancesSet/ec2:item');
-        foreach($is as $is_node) {
+        foreach ($is as $is_node) {
             $item = array();
 
             $item['instanceId'] = $xpath->evaluate('string(ec2:instanceId/text())', $is_node);
@@ -197,7 +196,6 @@ class Instance extends AbstractEc2
         unset($is);
 
         return $return;
-
     }
 
     /**
@@ -221,11 +219,11 @@ class Instance extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['InstanceId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['InstanceId.1'] = $instanceId;
         }
 
@@ -238,15 +236,17 @@ class Instance extends AbstractEc2
         $return = array();
         $return['instances'] = array();
 
-        foreach($nodes as $node) {
-            if($xpath->evaluate('string(ec2:instancesSet/ec2:item/ec2:instanceState/ec2:code/text())', $node) == 48 && $ignoreTerminated) continue;
+        foreach ($nodes as $node) {
+            if ($xpath->evaluate('string(ec2:instancesSet/ec2:item/ec2:instanceState/ec2:code/text())', $node) == 48 && $ignoreTerminated) {
+                continue;
+            }
             $item = array();
 
             $item['reservationId'] = $xpath->evaluate('string(ec2:reservationId/text())', $node);
             $item['ownerId'] = $xpath->evaluate('string(ec2:ownerId/text())', $node);
 
             $gs = $xpath->query('ec2:groupSet/ec2:item', $node);
-            foreach($gs as $gs_node) {
+            foreach ($gs as $gs_node) {
                 $item['groupSet'][] = $xpath->evaluate('string(ec2:groupId/text())', $gs_node);
                 unset($gs_node);
             }
@@ -254,8 +254,7 @@ class Instance extends AbstractEc2
 
             $is = $xpath->query('ec2:instancesSet/ec2:item', $node);
 
-            foreach($is as $is_node) {
-
+            foreach ($is as $is_node) {
                 $item['instanceId'] = $xpath->evaluate('string(ec2:instanceId/text())', $is_node);
                 $item['imageId'] = $xpath->evaluate('string(ec2:imageId/text())', $is_node);
                 $item['instanceState']['code'] = $xpath->evaluate('string(ec2:instanceState/ec2:code/text())', $is_node);
@@ -299,8 +298,10 @@ class Instance extends AbstractEc2
 
         $return = array();
 
-        foreach($arrInstances['instances'] as $instance) {
-            if($instance['imageId'] !== $imageId) continue;
+        foreach ($arrInstances['instances'] as $instance) {
+            if ($instance['imageId'] !== $imageId) {
+                continue;
+            }
             $return[] = $instance;
         }
 
@@ -321,11 +322,11 @@ class Instance extends AbstractEc2
         $params = array();
         $params['Action'] = 'TerminateInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['InstanceId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['InstanceId.1'] = $instanceId;
         }
 
@@ -335,7 +336,7 @@ class Instance extends AbstractEc2
         $nodes = $xpath->query('//ec2:instancesSet/ec2:item');
 
         $return = array();
-        foreach($nodes as $node) {
+        foreach ($nodes as $node) {
             $item = array();
 
             $item['instanceId'] = $xpath->evaluate('string(ec2:instanceId/text())', $node);
@@ -364,11 +365,11 @@ class Instance extends AbstractEc2
         $params = array();
         $params['Action'] = 'RebootInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['InstanceId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['InstanceId.1'] = $instanceId;
         }
 
@@ -431,7 +432,7 @@ class Instance extends AbstractEc2
 
         $result = $xpath->evaluate('string(//ec2:result/text())');
 
-        if($result === "true") {
+        if ($result === "true") {
             $return['result'] = true;
             $return['ownerId'] = $xpath->evaluate('string(//ec2:ownerId/text())');
 
@@ -452,11 +453,11 @@ class Instance extends AbstractEc2
         $params = array();
         $params['Action'] = 'MonitorInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['InstanceId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['InstanceId.1'] = $instanceId;
         }
 
@@ -467,7 +468,7 @@ class Instance extends AbstractEc2
         $items = $xpath->query('//ec2:instancesSet/ec2:item');
 
         $arrReturn = array();
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $i = array();
             $i['instanceid'] = $xpath->evaluate('string(//ec2:instanceId/text())', $item);
             $i['monitorstate'] = $xpath->evaluate('string(//ec2:monitoring/ec2:state/text())');
@@ -488,11 +489,11 @@ class Instance extends AbstractEc2
         $params = array();
         $params['Action'] = 'UnmonitorInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['InstanceId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['InstanceId.1'] = $instanceId;
         }
 
@@ -503,7 +504,7 @@ class Instance extends AbstractEc2
         $items = $xpath->query('//ec2:instancesSet/ec2:item');
 
         $arrReturn = array();
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $i = array();
             $i['instanceid'] = $xpath->evaluate('string(//ec2:instanceId/text())', $item);
             $i['monitorstate'] = $xpath->evaluate('string(//ec2:monitoring/ec2:state/text())');
@@ -513,5 +514,4 @@ class Instance extends AbstractEc2
 
         return $arrReturn;
     }
-
 }

--- a/library/ZendService/Amazon/Ec2/Keypair.php
+++ b/library/ZendService/Amazon/Ec2/Keypair.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * An Amazon EC2 interface to create, delete and describe Ec2 KeyPairs.
@@ -36,7 +35,7 @@ class Keypair extends AbstractEc2
 
         $params['Action'] = 'CreateKeyPair';
 
-        if(!$keyName) {
+        if (!$keyName) {
             throw new Exception\InvalidArgumentException('Invalid Key Name');
         }
 
@@ -66,11 +65,11 @@ class Keypair extends AbstractEc2
         $params = array();
 
         $params['Action'] = 'DescribeKeyPairs';
-        if(is_array($keyName) && !empty($keyName)) {
-            foreach($keyName as $k=>$name) {
+        if (is_array($keyName) && !empty($keyName)) {
+            foreach ($keyName as $k=>$name) {
                 $params['KeyName.' . ($k+1)] = $name;
             }
-        } elseif($keyName) {
+        } elseif ($keyName) {
             $params['KeyName.1'] = $keyName;
         }
 
@@ -105,7 +104,7 @@ class Keypair extends AbstractEc2
 
         $params['Action'] = 'DeleteKeyPair';
 
-        if(!$keyName) {
+        if (!$keyName) {
             throw new Exception\InvalidArgumentException('Invalid Key Name');
         }
 

--- a/library/ZendService/Amazon/Ec2/Region.php
+++ b/library/ZendService/Amazon/Ec2/Region.php
@@ -32,11 +32,11 @@ class Region extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeRegions';
 
-        if(is_array($region) && !empty($region)) {
-            foreach($region as $k=>$name) {
+        if (is_array($region) && !empty($region)) {
+            foreach ($region as $k=>$name) {
                 $params['Region.' . ($k+1)] = $name;
             }
-        } elseif($region) {
+        } elseif ($region) {
             $params['Region.1'] = $region;
         }
 

--- a/library/ZendService/Amazon/Ec2/ReservedInstance.php
+++ b/library/ZendService/Amazon/Ec2/ReservedInstance.php
@@ -30,11 +30,11 @@ class ReservedInstance extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeReservedInstances';
 
-        if(is_array($instanceId) && !empty($instanceId)) {
-            foreach($instanceId as $k=>$name) {
+        if (is_array($instanceId) && !empty($instanceId)) {
+            foreach ($instanceId as $k=>$name) {
                 $params['ReservedInstancesId.' . ($k+1)] = $name;
             }
-        } elseif($instanceId) {
+        } elseif ($instanceId) {
             $params['ReservedInstancesId.1'] = $instanceId;
         }
 
@@ -44,7 +44,7 @@ class ReservedInstance extends AbstractEc2
         $items = $xpath->query('//ec2:reservedInstancesSet/ec2:item');
 
         $return = array();
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $i = array();
             $i['reservedInstancesId'] = $xpath->evaluate('string(ec2:reservedInstancesId/text())', $item);
             $i['instanceType'] = $xpath->evaluate('string(ec2:instanceType/text())', $item);
@@ -82,7 +82,7 @@ class ReservedInstance extends AbstractEc2
         $items = $xpath->query('//ec2:reservedInstancesOfferingsSet/ec2:item');
 
         $return = array();
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $i = array();
             $i['reservedInstancesOfferingId'] = $xpath->evaluate('string(ec2:reservedInstancesOfferingId/text())', $item);
             $i['instanceType'] = $xpath->evaluate('string(ec2:instanceType/text())', $item);

--- a/library/ZendService/Amazon/Ec2/Response.php
+++ b/library/ZendService/Amazon/Ec2/Response.php
@@ -133,5 +133,4 @@ class Response
     {
         $this->_xmlNamespace = $namespace;
     }
-
 }

--- a/library/ZendService/Amazon/Ec2/SecurityGroups.php
+++ b/library/ZendService/Amazon/Ec2/SecurityGroups.php
@@ -62,11 +62,11 @@ class SecurityGroups extends AbstractEc2
     {
         $params = array();
         $params['Action'] = 'DescribeSecurityGroups';
-        if(is_array($name) && !empty($name)) {
-            foreach($name as $k=>$name) {
+        if (is_array($name) && !empty($name)) {
+            foreach ($name as $k=>$name) {
                 $params['GroupName.' . ($k+1)] = $name;
             }
-        } elseif($name) {
+        } elseif ($name) {
             $params['GroupName.1'] = $name;
         }
 
@@ -77,7 +77,7 @@ class SecurityGroups extends AbstractEc2
 
         $nodes = $xpath->query('//ec2:securityGroupInfo/ec2:item');
 
-        foreach($nodes as $node) {
+        foreach ($nodes as $node) {
             $item = array();
 
             $item['ownerId'] = $xpath->evaluate('string(ec2:ownerId/text())', $node);
@@ -86,7 +86,7 @@ class SecurityGroups extends AbstractEc2
 
             $ip_nodes = $xpath->query('ec2:ipPermissions/ec2:item', $node);
 
-            foreach($ip_nodes as $ip_node) {
+            foreach ($ip_nodes as $ip_node) {
                 $sItem = array();
 
                 $sItem['ipProtocol'] = $xpath->evaluate('string(ec2:ipProtocol/text())', $ip_node);
@@ -96,11 +96,11 @@ class SecurityGroups extends AbstractEc2
                 $ips = $xpath->query('ec2:ipRanges/ec2:item', $ip_node);
 
                 $sItem['ipRanges'] = array();
-                foreach($ips as $ip) {
+                foreach ($ips as $ip) {
                     $sItem['ipRanges'][] = $xpath->evaluate('string(ec2:cidrIp/text())', $ip);
                 }
 
-                if(count($sItem['ipRanges']) == 1) {
+                if (count($sItem['ipRanges']) == 1) {
                     $sItem['ipRanges'] = $sItem['ipRanges'][0];
                 }
 
@@ -177,7 +177,6 @@ class SecurityGroups extends AbstractEc2
         $success  = $xpath->evaluate('string(//ec2:return/text())');
 
         return ($success === "true");
-
     }
 
     /**

--- a/library/ZendService/Amazon/Ec2/WindowsInstance.php
+++ b/library/ZendService/Amazon/Ec2/WindowsInstance.php
@@ -102,11 +102,11 @@ class WindowsInstance extends AbstractEc2
         $params = array();
         $params['Action'] = 'DescribeBundleTasks';
 
-        if(is_array($bundleId) && !empty($bundleId)) {
-            foreach($bundleId as $k=>$name) {
+        if (is_array($bundleId) && !empty($bundleId)) {
+            foreach ($bundleId as $k=>$name) {
                 $params['bundleId.' . ($k+1)] = $name;
             }
-        } elseif(!empty($bundleId)) {
+        } elseif (!empty($bundleId)) {
             $params['bundleId.1'] = $bundleId;
         }
 
@@ -117,7 +117,7 @@ class WindowsInstance extends AbstractEc2
         $items = $xpath->evaluate('//ec2:bundleInstanceTasksSet/ec2:item');
         $return = array();
 
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $i = array();
             $i['instanceId'] = $xpath->evaluate('string(ec2:instanceId/text())', $item);
             $i['bundleId'] = $xpath->evaluate('string(ec2:bundleId/text())', $item);

--- a/library/ZendService/Amazon/S3/S3.php
+++ b/library/ZendService/Amazon/S3/S3.php
@@ -15,7 +15,6 @@ use Zend\Crypt\Hmac;
 use Zend\Http\Header;
 use Zend\Http\Response\Stream as StreamResponse;
 use ZendService\Amazon;
-use ZendService\Amazon\S3\Exception;
 use Zend\Uri;
 
 /**
@@ -253,15 +252,15 @@ class S3 extends \ZendService\Amazon\AbstractAmazon
             $info['etag']  = $headers->get('ETag');
 
             //Prevents from the fatal error method call on a non-object
-            foreach ($info as $key => $value)
+            foreach ($info as $key => $value) {
                 if ($value instanceof Header\HeaderInterface) {
                     $info[$key] = $value->getFieldValue();
                 }
+            }
 
             if ($info['mtime']) {
                 $info['mtime'] = strtotime($headers->get('Last-modified')->getFieldValue());
             }
-
         } else {
             return false;
         }
@@ -531,7 +530,7 @@ class S3 extends \ZendService\Amazon\AbstractAmazon
         }
 
         if (!isset($meta[self::S3_CONTENT_TYPE_HEADER])) {
-           $meta[self::S3_CONTENT_TYPE_HEADER] = self::getMimeType($path);
+            $meta[self::S3_CONTENT_TYPE_HEADER] = self::getMimeType($path);
         }
 
         return $this->putObject($object, $data, $meta);
@@ -558,7 +557,7 @@ class S3 extends \ZendService\Amazon\AbstractAmazon
         }
 
         if (!isset($meta[self::S3_CONTENT_TYPE_HEADER])) {
-           $meta[self::S3_CONTENT_TYPE_HEADER] = self::getMimeType($path);
+            $meta[self::S3_CONTENT_TYPE_HEADER] = self::getMimeType($path);
         }
 
         if (!isset($meta['Content-MD5'])) {
@@ -816,8 +815,9 @@ class S3 extends \ZendService\Amazon\AbstractAmazon
         //US General bucket names must always be lowercased for the signature
         $urlPath = parse_url($path, PHP_URL_PATH);
         $urlPathParts = explode('/', $urlPath);
-        if (!empty($urlPathParts[0]))
+        if (!empty($urlPathParts[0])) {
             $urlPathParts[0] = strtolower($urlPathParts[0]);
+        }
 
         $sig_str .= '/'.implode('/', $urlPathParts);
         if (strpos($path, '?location') !== false) {

--- a/library/ZendService/Amazon/S3/Stream.php
+++ b/library/ZendService/Amazon/S3/Stream.php
@@ -11,7 +11,6 @@
 namespace ZendService\Amazon\S3;
 
 use ZendService\Amazon;
-use ZendService\Amazon\S3\Exception;
 
 /**
  * Amazon S3 PHP stream wrapper
@@ -180,7 +179,6 @@ class Stream
         // buffer AND if the range end position is less than or equal to the object's
         // size returned by S3
         if (($this->_position == 0) || (($range_end > strlen($this->_objectBuffer)) && ($range_end <= $this->_objectSize))) {
-
             $headers = array(
                 'Range' => "bytes=$range_start-$range_end"
             );
@@ -319,13 +317,13 @@ class Stream
         $stat['blksize'] = 0;
         $stat['blocks'] = 0;
 
-    if(($slash = strchr($this->_objectName, '/')) === false || $slash == strlen($this->_objectName)-1) {
-        /* bucket */
+        if (($slash = strchr($this->_objectName, '/')) === false || $slash == strlen($this->_objectName)-1) {
+            /* bucket */
         $stat['mode'] |= 040000;
-    } else {
-        $stat['mode'] |= 0100000;
-    }
-           $info = $this->_s3->getInfo($this->_objectName);
+        } else {
+            $stat['mode'] |= 0100000;
+        }
+        $info = $this->_s3->getInfo($this->_objectName);
         if (!empty($info)) {
             $stat['size']  = $info['size'];
             $stat['atime'] = time();
@@ -393,7 +391,6 @@ class Stream
      */
     public function dir_opendir($path, $options)
     {
-
         if (preg_match('@^([a-z0-9+.]|-)+://$@', $path)) {
             $this->_bucketList = $this->_getS3Client($path)->getBuckets();
         } else {
@@ -428,14 +425,14 @@ class Stream
         $stat['blksize'] = 0;
         $stat['blocks'] = 0;
 
-    $name = $this->_getNamePart($path);
-    if(($slash = strchr($name, '/')) === false || $slash == strlen($name)-1) {
-        /* bucket */
+        $name = $this->_getNamePart($path);
+        if (($slash = strchr($name, '/')) === false || $slash == strlen($name)-1) {
+            /* bucket */
         $stat['mode'] |= 040000;
-    } else {
-        $stat['mode'] |= 0100000;
-    }
-           $info = $this->_getS3Client($path)->getInfo($name);
+        } else {
+            $stat['mode'] |= 0100000;
+        }
+        $info = $this->_getS3Client($path)->getInfo($name);
 
         if (!empty($info)) {
             $stat['size']  = $info['size'];

--- a/library/ZendService/Amazon/SimpleDb/Attribute.php
+++ b/library/ZendService/Amazon/SimpleDb/Attribute.php
@@ -79,7 +79,7 @@ class Attribute
     public function addValue($value)
     {
         if (is_array($value)) {
-             $this->_values += $value;
+            $this->_values += $value;
         } else {
             $this->_values[] = $value;
         }

--- a/library/ZendService/Amazon/SimpleDb/SimpleDb.php
+++ b/library/ZendService/Amazon/SimpleDb/SimpleDb.php
@@ -71,10 +71,10 @@ class SimpleDb extends \ZendService\Amazon\AbstractAmazon
      */
     public function setEndpoint($endpoint)
     {
-        if(!($endpoint instanceof Uri\Uri)) {
+        if (!($endpoint instanceof Uri\Uri)) {
             $endpoint = Uri\UriFactory::factory($endpoint);
         }
-        if(!$endpoint->isValid()) {
+        if (!$endpoint->isValid()) {
             throw new Exception\InvalidArgumentException("Invalid endpoint supplied");
         }
         $this->_endpoint = $endpoint;
@@ -118,13 +118,13 @@ class SimpleDb extends \ZendService\Amazon\AbstractAmazon
 
         // Return an array of arrays
         $attributes = array();
-        foreach($attributeNodes as $attributeNode) {
+        foreach ($attributeNodes as $attributeNode) {
             $name       = (string)$attributeNode->Name;
             $valueNodes = $attributeNode->Value;
             $data       = null;
             if (is_array($valueNodes) && !empty($valueNodes)) {
                 $data = array();
-                foreach($valueNodes as $valueNode) {
+                foreach ($valueNodes as $valueNode) {
                     $data[] = (string)$valueNode;
                 }
             } elseif (isset($valueNodes)) {
@@ -164,7 +164,7 @@ class SimpleDb extends \ZendService\Amazon\AbstractAmazon
                 $params['Attribute.' . $index . '.Value'] = $value;
 
                 // Check if it should be replaced
-                if(array_key_exists($attributeName, $replace) && $replace[$attributeName]) {
+                if (array_key_exists($attributeName, $replace) && $replace[$attributeName]) {
                     $params['Attribute.' . $index . '.Replace'] = 'true';
                 }
                 $index++;
@@ -185,7 +185,6 @@ class SimpleDb extends \ZendService\Amazon\AbstractAmazon
      */
     public function batchPutAttributes($items, $domainName, array $replace = array())
     {
-
         $params               = array();
         $params['Action']     = 'BatchPutAttributes';
         $params['DomainName'] = $domainName;
@@ -197,7 +196,7 @@ class SimpleDb extends \ZendService\Amazon\AbstractAmazon
             foreach ($attributes as $attribute) {
                 // attribute value cannot be array, so when several items are passed
                 // they are treated as separate values with the same attribute name
-                foreach($attribute->getValues() as $value) {
+                foreach ($attribute->getValues() as $value) {
                     $params['Item.' . $itemIndex . '.Attribute.' . $attributeIndex . '.Name'] = $attribute->getName();
                     $params['Item.' . $itemIndex . '.Attribute.' . $attributeIndex . '.Value'] = $value;
                     if (isset($replace[$name])

--- a/library/ZendService/Amazon/Sqs/Sqs.php
+++ b/library/ZendService/Amazon/Sqs/Sqs.php
@@ -13,7 +13,6 @@ namespace ZendService\Amazon\Sqs;
 use SimpleXMLElement;
 use Zend\Crypt\Hmac;
 use ZendService\Amazon;
-use ZendService\Amazon\Sqs\Exception;
 
 /**
  * Class for connecting to the Amazon Simple Queue Service (SQS)
@@ -102,7 +101,6 @@ class Sqs extends Amazon\AbstractAmazon
             } else {
                 return (string) $result->CreateQueueResult->QueueUrl;
             }
-
         } while ($retry);
 
         return false;
@@ -275,9 +273,9 @@ class Sqs extends Amazon\AbstractAmazon
             throw new Exception\RuntimeException($result->Error->Code);
         }
 
-        if(count($result->GetQueueAttributesResult->Attribute) > 1) {
+        if (count($result->GetQueueAttributesResult->Attribute) > 1) {
             $attr_result = array();
-            foreach($result->GetQueueAttributesResult->Attribute as $attribute) {
+            foreach ($result->GetQueueAttributesResult->Attribute as $attribute) {
                 $attr_result[(string)$attribute->Name] = (string)$attribute->Value;
             }
             return $attr_result;
@@ -406,7 +404,7 @@ class Sqs extends Amazon\AbstractAmazon
         unset($parameters['Signature']);
 
         $arrData = array();
-        foreach($parameters as $key => $value) {
+        foreach ($parameters as $key => $value) {
             $arrData[] = $key . '=' . str_replace('%7E', '~', urlencode($value));
         }
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -11,7 +11,7 @@
 /*
  * Set error reporting to the level to which Zend Framework code must comply.
  */
-error_reporting( E_ALL | E_STRICT );
+error_reporting(E_ALL | E_STRICT);
 
 $phpUnitVersion = PHPUnit_Runner_Version::id();
 if ('@package_version@' !== $phpUnitVersion && version_compare($phpUnitVersion, '3.5.0', '<')) {

--- a/tests/ZendService/Amazon/Authentication/S3Test.php
+++ b/tests/ZendService/Amazon/Authentication/S3Test.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Authentication;
 
 use ZendService\Amazon\Authentication;
-use ZendService\Amazon\Authentication\Exception;
 
 /**
  * S3 authentication test case
@@ -34,7 +33,6 @@ class S3Test extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->_amazon = new Authentication\S3('0PN5J17HBGZHT7JJ3X82', 'uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o', '2006-03-01');
-
     }
 
     /**
@@ -107,7 +105,6 @@ class S3Test extends \PHPUnit_Framework_TestCase
 
     public function testDeleteGeneratesCorrectSignature()
     {
-
         $headers = array();
         $headers['x-amz-date'] = "Tue, 27 Mar 2007 21:20:26 +0000";
 
@@ -150,5 +147,4 @@ class S3Test extends \PHPUnit_Framework_TestCase
                     . "//static.johnsmith.net/db-backup.dat.gz";
         $this->assertEquals($ret, $rawHttpResponse);
     }
-
 }

--- a/tests/ZendService/Amazon/Authentication/V1Test.php
+++ b/tests/ZendService/Amazon/Authentication/V1Test.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Authentication;
 
 use ZendService\Amazon\Authentication;
-use ZendService\Amazon\Authentication\Exception;
 
 /**
  * Amazon V1 authentication test case
@@ -59,5 +58,4 @@ class V1Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('31Q2YlgABM5X3GkYQpGErcL10Xc=', $params['Signature']);
         $this->assertEquals("ActionActivateHostedProductAWSAccessKeyId0PN5J17HBGZHT7JJ3X82SignatureVersion1Timestamp2009-11-11T13:52:38ZVersion2007-12-01", $ret);
     }
-
 }

--- a/tests/ZendService/Amazon/Authentication/V2Test.php
+++ b/tests/ZendService/Amazon/Authentication/V2Test.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Authentication;
 
 use ZendService\Amazon\Authentication;
-use ZendService\Amazon\Authentication\Exception;
 
 /**
  * Amazon V2 authentication test case
@@ -76,5 +75,4 @@ class V2Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals('YSw7HXDqokM/A6DhLz8kG+sd+oD5eMjqx3a02A0+GkE=', $params['Signature']);
         $this->assertEquals(str_replace("\r\n", "\n", file_get_contents(dirname(__FILE__) . '/_files/sqs_v2_get_return.txt')), $ret);
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/AbstractTest.php
+++ b/tests/ZendService/Amazon/Ec2/AbstractTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon;
-use ZendService\Amazon\Ec2\Exception;
 
 /**
  * @category   Zend

--- a/tests/ZendService/Amazon/Ec2/AvailabilityZonesTest.php
+++ b/tests/ZendService/Amazon/Ec2/AvailabilityZonesTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2;
-use ZendService\Amazon\Ec2\Exception;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 

--- a/tests/ZendService/Amazon/Ec2/CloudWatchTest.php
+++ b/tests/ZendService/Amazon/Ec2/CloudWatchTest.php
@@ -108,7 +108,6 @@ class CloudWatchTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrReturn, $return);
-
     }
 
     /**
@@ -189,7 +188,6 @@ class CloudWatchTest extends \PHPUnit_Framework_TestCase
 
     public function testZF8149()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -251,40 +249,40 @@ class CloudWatchTest extends \PHPUnit_Framework_TestCase
            )
         );
 
-        $arrReturn = array (
+        $arrReturn = array(
           'label' => 'CPUUtilization',
           'datapoints' =>
-          array (
+          array(
             0 =>
-            array (
+            array(
               'Timestamp' => '2009-11-19T21:52:00Z',
               'Unit' => 'Percent',
               'Samples' => '1.0',
               'Average' => '0.09',
             ),
             1 =>
-            array (
+            array(
               'Timestamp' => '2009-11-19T21:55:00Z',
               'Unit' => 'Percent',
               'Samples' => '1.0',
               'Average' => '0.18',
             ),
             2 =>
-            array (
+            array(
               'Timestamp' => '2009-11-19T21:54:00Z',
               'Unit' => 'Percent',
               'Samples' => '1.0',
               'Average' => '0.09',
             ),
             3 =>
-            array (
+            array(
               'Timestamp' => '2009-11-19T21:51:00Z',
               'Unit' => 'Percent',
               'Samples' => '1.0',
               'Average' => '0.18',
             ),
             4 =>
-            array (
+            array(
               'Timestamp' => '2009-11-19T21:53:00Z',
               'Unit' => 'Percent',
               'Samples' => '1.0',
@@ -295,5 +293,4 @@ class CloudWatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($arrReturn, $return);
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/EbsTest.php
+++ b/tests/ZendService/Amazon/Ec2/EbsTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2;
-
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 
@@ -89,7 +88,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateSnapshot()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -119,7 +117,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrCreateSnapShot, $return);
-
     }
 
     public function testCreateNewVolume()
@@ -154,7 +151,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrCreateNewVolume, $return);
-
     }
 
     public function testCreateVolumeFromSnapshot()
@@ -190,12 +186,10 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrCreateNewVolume, $return);
-
     }
 
     public function testDeleteSnapshot()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -213,7 +207,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         $return = $this->ebsInstance->deleteSnapshot('snap-78a54011');
 
         $this->assertTrue($return);
-
     }
 
     public function testDeleteVolume()
@@ -275,8 +268,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertSame($arrSnapshot, $return);
-
-
     }
 
     public function testDescribeMultipleSnapshots()
@@ -330,7 +321,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrSnapshots, $return);
-
     }
 
     /**
@@ -338,7 +328,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
      */
     public function testDescribeSingleVolume()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -390,12 +379,10 @@ class EbsTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrVolumes, $return);
-
     }
 
     public function testDescribeMultipleVolume()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -463,7 +450,6 @@ class EbsTest extends \PHPUnit_Framework_TestCase
 
     public function testDescribeAttachedVolumes()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -558,5 +544,4 @@ class EbsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($arrVolume, $return);
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/ElasticIpTest.php
+++ b/tests/ZendService/Amazon/Ec2/ElasticIpTest.php
@@ -91,7 +91,6 @@ class ElasticIpTest extends \PHPUnit_Framework_TestCase
         $return = $this->elasticip->associate('67.202.55.255', 'i-ag8ga0a');
 
         $this->assertTrue($return);
-
     }
 
     /**
@@ -166,7 +165,7 @@ class ElasticIpTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        foreach($response as $k => $r) {
+        foreach ($response as $k => $r) {
             $this->assertSame($arrIps[$k], $r);
         }
     }
@@ -193,7 +192,6 @@ class ElasticIpTest extends \PHPUnit_Framework_TestCase
         $return = $this->elasticip->disassocate('67.202.55.255');
 
         $this->assertTrue($return);
-
     }
 
     /**
@@ -218,7 +216,5 @@ class ElasticIpTest extends \PHPUnit_Framework_TestCase
         $return = $this->elasticip->release('67.202.55.255');
 
         $this->assertTrue($return);
-
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/ImageTest.php
+++ b/tests/ZendService/Amazon/Ec2/ImageTest.php
@@ -11,8 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2;
-use ZendService\Amazon\Ec2\Exception;
-
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 
@@ -73,7 +71,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $return = $this->ec2ImageInstance->deregister('ami-61a54008');
 
         $this->assertTrue($return);
-
     }
 
     public function testDescribeSingleImageMultipleImagesByIds()
@@ -554,7 +551,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $return = $this->ec2ImageInstance->modifyAttribute('ami-61a54008', 'productCodes', null, null, null, '774F4FF8');
 
         $this->assertTrue($return);
-
     }
 
     public function testRegister()
@@ -576,7 +572,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $return = $this->ec2ImageInstance->register('mybucket-myimage.manifest.xml');
 
         $this->assertEquals('ami-61a54008', $return);
-
     }
 
     public function testResetAttribute()
@@ -598,7 +593,5 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $return = $this->ec2ImageInstance->resetAttribute('ami-61a54008', 'launchPermission');
 
         $this->assertTrue($return);
-
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/InstanceReservedTest.php
+++ b/tests/ZendService/Amazon/Ec2/InstanceReservedTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2\ReservedInstance;
-
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 
@@ -103,7 +102,6 @@ class InstanceReservedTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrReturn, $return);
-
     }
 
     /**
@@ -150,7 +148,6 @@ class InstanceReservedTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($arrReturn, $return);
-
     }
 
     /**
@@ -175,7 +172,5 @@ class InstanceReservedTest extends \PHPUnit_Framework_TestCase
         $return = $this->instance->purchaseOffering('4b2293b4-5813-4cc8-9ce3-1957fc1dcfc8');
 
         $this->assertSame('4b2293b4-5813-4cc8-9ce3-1957fc1dcfc8', $return);
-
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/InstanceTest.php
+++ b/tests/ZendService/Amazon/Ec2/InstanceTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2\Instance;
-use ZendService\Amazon\Ec2\Exception;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 
@@ -398,11 +397,10 @@ class InstanceTest extends \PHPUnit_Framework_TestCase
 
         $arrInstanceIds = array('i-2ba64342', 'i-2bc64242', 'i-2be64332');
 
-        foreach($return['instances'] as $k => $r) {
+        foreach ($return['instances'] as $k => $r) {
             $this->assertEquals($arrInstanceIds[$k], $r['instanceId']);
             $this->assertEquals($k, $r['amiLaunchIndex']);
         }
-
     }
 
     public function testRunMultipleSecurityGroups()
@@ -500,7 +498,7 @@ class InstanceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($return));
 
-        foreach($return as $r) {
+        foreach ($return as $r) {
             $this->assertEquals('i-28a64341', $r['instanceId']);
         }
     }
@@ -550,7 +548,7 @@ class InstanceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(2, count($return));
 
-        foreach($return as $k=>$r) {
+        foreach ($return as $k=>$r) {
             $this->assertEquals($arrInstanceIds[$k], $r['instanceId']);
         }
     }
@@ -699,5 +697,4 @@ class InstanceTest extends \PHPUnit_Framework_TestCase
         $arrReturn = array(array('instanceid' => 'i-43a4412a', 'monitorstate' => 'pending'));
         $this->assertSame($arrReturn, $return);
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/InstanceWindowsTest.php
+++ b/tests/ZendService/Amazon/Ec2/InstanceWindowsTest.php
@@ -99,8 +99,7 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
                 "updateTime" => "2008-10-07T11:51:50.000Z",
                 "progress" => "20%",
                 "storage" => array(
-                        "s3" => array
-                            (
+                        "s3" => array(
                                 "bucket" => "my-bucket",
                                 "prefix" => "my-new-image"
                             )
@@ -108,7 +107,6 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
                 );
 
         $this->assertSame($arrReturn, $return);
-
     }
 
     /**
@@ -152,8 +150,7 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
                 "updateTime" => "2008-10-07T11:51:50.000Z",
                 "progress" => "20%",
                 "storage" => array(
-                        "s3" => array
-                            (
+                        "s3" => array(
                                 "bucket" => "my-bucket",
                                 "prefix" => "my-new-image"
                             )
@@ -161,9 +158,6 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
                 );
 
         $this->assertSame($arrReturn, $return);
-
-
-
     }
 
     /**
@@ -211,8 +205,7 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
                 "updateTime" => "2008-10-07T11:51:50.000Z",
                 "progress" => "20%",
                 "storage" => array(
-                        "s3" => array
-                            (
+                        "s3" => array(
                                 "bucket" => "my-bucket",
                                 "prefix" => "my-new-image"
                             )
@@ -221,7 +214,5 @@ class InstanceWindowsTest extends \PHPUnit_Framework_TestCase
             );
 
         $this->assertSame($arrReturn, $return);
-
     }
-
 }

--- a/tests/ZendService/Amazon/Ec2/KeypairTest.php
+++ b/tests/ZendService/Amazon/Ec2/KeypairTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\Ec2;
 
 use ZendService\Amazon\Ec2;
-use ZendService\Amazon\Ec2\Exception;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as HttpClientTestAdapter;
 
@@ -179,7 +178,7 @@ class KeypairTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        foreach($response as $k => $r) {
+        foreach ($response as $k => $r) {
             $this->assertSame($arrKeys[$k], $r);
         }
     }

--- a/tests/ZendService/Amazon/Ec2/RegionTest.php
+++ b/tests/ZendService/Amazon/Ec2/RegionTest.php
@@ -111,7 +111,7 @@ class RegionTest extends \PHPUnit_Framework_TestCase
                     . "</DescribeRegionsResponse>";
         $this->httpClientTestAdapter->setResponse($rawHttpResponse);
 
-        $response = $this->regionInstance->describe(array('us-east-1','us-west-1'));
+        $response = $this->regionInstance->describe(array('us-east-1', 'us-west-1'));
 
         $arrRegion = array(
             array(

--- a/tests/ZendService/Amazon/Ec2/SecurityGroupsTest.php
+++ b/tests/ZendService/Amazon/Ec2/SecurityGroupsTest.php
@@ -75,7 +75,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->authorizeIp('MyGroup', 'tcp', '80', '80', '0.0.0.0/0');
         $this->assertTrue($return);
-
     }
 
     public function testAuthorizeRangeOfPorts()
@@ -97,7 +96,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->authorizeIp('MyGroup', 'tcp', '6000', '7000', '0.0.0.0/0');
         $this->assertTrue($return);
-
     }
 
     public function testAuthorizeSecurityGroupName()
@@ -119,7 +117,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->authorizeGroup('MyGroup', 'groupname', '15333848');
         $this->assertTrue($return);
-
     }
 
     /**
@@ -127,7 +124,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreate()
     {
-
         $rawHttpResponse = "HTTP/1.1 200 OK\r\n"
                     . "Date: Fri, 24 Oct 2008 17:24:52 GMT\r\n"
                     . "Server: hi\r\n"
@@ -146,7 +142,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
         $return = $this->securitygroupsInstance->create('MyGroup', 'My Security Grup');
 
         $this->assertTrue($return);
-
     }
 
     /**
@@ -172,7 +167,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
         $return = $this->securitygroupsInstance->delete('MyGroup');
 
         $this->assertTrue($return);
-
     }
 
     /**
@@ -231,7 +225,7 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
                     . "</DescribeSecurityGroupsResponse>\r\n";
         $this->httpClientTestAdapter->setResponse($rawHttpResponse);
 
-        $return = $this->securitygroupsInstance->describe(array('WebServers','RangedPortsBySource'));
+        $return = $this->securitygroupsInstance->describe(array('WebServers', 'RangedPortsBySource'));
 
         $this->assertEquals(2, count($return));
 
@@ -259,7 +253,7 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
                     ))
                 )
             );
-        foreach($return as $k => $r) {
+        foreach ($return as $k => $r) {
             $this->assertSame($arrGroups[$k], $r);
         }
     }
@@ -316,7 +310,7 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
                     ))
                 )
             );
-        foreach($return as $k => $r) {
+        foreach ($return as $k => $r) {
             $this->assertSame($arrGroups[$k], $r);
         }
     }
@@ -379,7 +373,7 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
                     ))
                 )
             );
-        foreach($return as $k => $r) {
+        foreach ($return as $k => $r) {
             $this->assertSame($arrGroups[$k], $r);
         }
     }
@@ -406,7 +400,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->revokeIp('MyGroup', 'tcp', '80', '80', '0.0.0.0/0');
         $this->assertTrue($return);
-
     }
 
     public function testRevokePortRange()
@@ -428,7 +421,6 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->revokeIp('MyGroup', 'tcp', '6000', '7000', '0.0.0.0/0');
         $this->assertTrue($return);
-
     }
 
 
@@ -451,7 +443,5 @@ class SecurityGroupsTest extends \PHPUnit_Framework_TestCase
 
         $return = $this->securitygroupsInstance->revokeGroup('MyGroup', 'groupname', '15333848');
         $this->assertTrue($return);
-
     }
-
 }

--- a/tests/ZendService/Amazon/OfflineTest.php
+++ b/tests/ZendService/Amazon/OfflineTest.php
@@ -10,8 +10,8 @@
 
 namespace ZendServiceTest\Amazon;
 
-use ZendService\Amazon,
-    Zend\Http\Client\Adapter\Test as HttpClientAdapter;
+use ZendService\Amazon;
+use Zend\Http\Client\Adapter\Test as HttpClientAdapter;
 
 /**
  * Test helper
@@ -88,7 +88,7 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
 
         $result = new Amazon\ResultSet($dom);
 
-        foreach($result AS $item) {
+        foreach ($result as $item) {
             $trackCount = $mozartTracks[$item->ASIN];
             $this->assertEquals($trackCount, count($item->Tracks));
         }
@@ -209,9 +209,9 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
 
         $result = new Amazon\ResultSet($dom);
 
-        foreach($result AS $item) {
+        foreach ($result as $item) {
             $data = $dataExpected[$item->ASIN];
-            foreach($item->Offers->Offers as $offer) {
+            foreach ($item->Offers->Offers as $offer) {
                 $this->assertEquals($data['offers'][$offer->MerchantId]['name'], $offer->MerchantName);
                 $this->assertEquals($data['offers'][$offer->MerchantId]['price'], $offer->Price);
             }

--- a/tests/ZendService/Amazon/OnlineTest.php
+++ b/tests/ZendService/Amazon/OnlineTest.php
@@ -52,7 +52,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         if (!constant('TESTS_ZEND_SERVICE_AMAZON_ONLINE_ENABLED')) {
             $this->markTestSkipped('Zend_Service_Amazon_S3 online tests are not enabled');
         }
-        if(!defined('TESTS_ZEND_SERVICE_AMAZON_ONLINE_ACCESSKEYID') || !defined('TESTS_ZEND_SERVICE_AMAZON_ONLINE_SECRETKEY')) {
+        if (!defined('TESTS_ZEND_SERVICE_AMAZON_ONLINE_ACCESSKEYID') || !defined('TESTS_ZEND_SERVICE_AMAZON_ONLINE_SECRETKEY')) {
             $this->markTestSkipped('Constants AccessKeyId and SecretKey have to be set.');
         }
 

--- a/tests/ZendService/Amazon/S3/OfflineTest.php
+++ b/tests/ZendService/Amazon/S3/OfflineTest.php
@@ -11,7 +11,6 @@
 namespace ZendServiceTest\Amazon\S3;
 
 use ZendService\Amazon\S3\S3;
-use ReflectionProperty;
 
 /**
  * @category   Zend

--- a/tests/ZendService/Amazon/S3/OnlineTest.php
+++ b/tests/ZendService/Amazon/S3/OnlineTest.php
@@ -188,7 +188,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
         $this->_amazon->putObject($this->_bucket."/zftest.jpg", $data, null);
         $info = $this->_amazon->getInfo($this->_bucket."/zftest.jpg");
-        $this->assertEquals( 'image/jpeg', $info["type"]);
+        $this->assertEquals('image/jpeg', $info["type"]);
     }
 
     public function testNoBucket()
@@ -254,7 +254,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
     protected function _fileTest($filename, $object, $type, $exp_type, $stream = false)
     {
-        if($stream) {
+        if ($stream) {
             $this->_amazon->putFile($filename, $object, array(S3\S3::S3_CONTENT_TYPE_HEADER => $type));
         } else {
             $this->_amazon->putFileStream($filename, $object, array(S3\S3::S3_CONTENT_TYPE_HEADER => $type));
@@ -517,14 +517,13 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $this->_amazon->createBucket("127.0.0.1");
-        } catch(S3\Exception\InvalidArgumentException $e) {
+        } catch (S3\Exception\InvalidArgumentException $e) {
             $this->_amazon->createBucket("123-456-789-123");
             $this->assertTrue($this->_amazon->isBucketAvailable("123-456-789-123"));
             $this->_amazon->removeBucket("123-456-789-123");
             return;
         }
         $this->fail("Failed to throw expected exception");
-
     }
 
     /**
@@ -557,8 +556,8 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         );
         $response = $this->_amazon->getObjectsAndPrefixesByBucket($this->_bucket, $params);
 
-        $this->assertEquals($response['objects'][0],'test-folder/test1');
-        $this->assertEquals($response['prefixes'][0],'test-folder/test2-folder/');
+        $this->assertEquals($response['objects'][0], 'test-folder/test1');
+        $this->assertEquals($response['prefixes'][0], 'test-folder/test2-folder/');
     }
 
     public function tearDown()

--- a/tests/ZendService/Amazon/S3/S3RestTest.php
+++ b/tests/ZendService/Amazon/S3/S3RestTest.php
@@ -58,7 +58,6 @@ class S3RestTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-
         $accessKey = 'accessKey';
         $secretKey = 'secretKey';
 
@@ -203,7 +202,6 @@ BODY;
      */
     public function testValidBucketName()
     {
-
         $this->assertTrue($this->amazon->_validBucketName('iam.avalid.1bucket-name.endingwithnumber9'));
     }
 

--- a/tests/ZendService/Amazon/S3/StreamTest.php
+++ b/tests/ZendService/Amazon/S3/StreamTest.php
@@ -61,8 +61,8 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         }
         $this->_amazon->unregisterStreamWrapper();
         $buckets = $this->_amazon->getBuckets();
-        foreach($buckets as $bucket) {
-            if(substr($bucket, 0, strlen($this->_bucket)) != $this->_bucket) {
+        foreach ($buckets as $bucket) {
+            if (substr($bucket, 0, strlen($this->_bucket)) != $this->_bucket) {
                 continue;
             }
             $this->_amazon->cleanBucket($bucket);

--- a/tests/ZendService/Amazon/SimpleDb/OnlineTest.php
+++ b/tests/ZendService/Amazon/SimpleDb/OnlineTest.php
@@ -143,7 +143,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($attributeValue2, current($results[$attributeName2]->getValues()));
 
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -176,7 +176,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($attributes[$attributeName1], $results[$attributeName1]);
             $this->assertEquals($attributes[$attributeName2], $results[$attributeName2]);
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -269,7 +269,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($items[$itemName1], $this->request('getAttributes', array($domainName, $itemName1)));
 
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -336,7 +336,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(0, count($results));
 
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -353,7 +353,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         $domainName = null;
         try {
             // Create some domains
-            for($i = 1; $i <= 3; $i++) {
+            for ($i = 1; $i <= 3; $i++) {
                 $domainName = $this->_testDomainNamePrefix . '_testListDomains' . $i;
                 $this->request('deleteDomain', array($domainName));
                 $this->request('createDomain', array($domainName));
@@ -364,23 +364,23 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             // Amazon returns an empty page as the last page :/
             $isLast = $page->isLast();
             if (!$isLast) {
-              // The old isLast() assertTrue failed in full suite runs. Token often
+                // The old isLast() assertTrue failed in full suite runs. Token often
               // decodes to 'TestsZendServiceAmazonSimpleDbDomain_testPutAttributes'
               // which no longer exists. Instead of a plain assertTrue, which seemed
               // to pass only in single-case runs, we'll make sure the token's
               // presence is worth a negative.
               $token = $page->getToken();
-              if ($token) {
-                $tokenDomainName = base64_decode($token);
-                if (false !== strpos($tokenDomainName, $this->_testDomainNamePrefix)) {
-                  try {
-                    $this->request('domainMetadata', array($tokenDomainName));
-                    $this->fail('listDomains call with 3 domain maximum did not return last page');
-                  } catch (Exception $e) {
-                    $this->assertContains('The specified domain does not exist', $e->getMessage());
-                  }
+                if ($token) {
+                    $tokenDomainName = base64_decode($token);
+                    if (false !== strpos($tokenDomainName, $this->_testDomainNamePrefix)) {
+                        try {
+                            $this->request('domainMetadata', array($tokenDomainName));
+                            $this->fail('listDomains call with 3 domain maximum did not return last page');
+                        } catch (Exception $e) {
+                            $this->assertContains('The specified domain does not exist', $e->getMessage());
+                        }
+                    }
                 }
-              }
             }
             $this->assertEquals(1, count($this->request('listDomains', array(1, $page->getToken()))));
 
@@ -398,13 +398,13 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($nextPage->isLast());
 
             // Delete the domains
-            for($i = 1; $i <= 3; $i++) {
+            for ($i = 1; $i <= 3; $i++) {
                 $domainName = $this->_testDomainNamePrefix . '_testListDomains' . $i;
                 $this->request('deleteDomain', array($domainName));
             }
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             // Delete the domains
-            for($i = 1; $i <= 3; $i++) {
+            for ($i = 1; $i <= 3; $i++) {
                 $domainName = $this->_testDomainNamePrefix . '_testListDomains' . $i;
                 $this->request('deleteDomain', array($domainName));
             }
@@ -441,7 +441,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
             // Delete the domain
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -462,7 +462,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->assertContains($domainName, $domainListPage->getData());
             // Delete the domain
             $this->request('deleteDomain', array($domainName));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }
@@ -481,7 +481,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $this->request('deleteDomain', array($domainName));
             $domainListPage = $this->request('listDomains');
             $this->assertNotContains($domainName, $domainListPage->getData());
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->request('deleteDomain', array($domainName));
             throw $e;
         }

--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -12,7 +12,6 @@ if ($zf2Path = getenv('ZF2_PATH')) {
         )
     ));
     $loader->register();
-
 } elseif (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
     throw new RuntimeException('This component has dependencies that are unmet.
 


### PR DESCRIPTION
- Added PHPUnit and php-cs-fixer as dev dependencies.
- Setup PSR-0 dev autoloading for tests.
- Added php-cs-fixer configuration.
- Updated Travis-CI configuration to:
 - Add testing for 5.5, 5.6, 7, and hhvm.
 - Use the phpunit and php-cs-fixer installed by composer.
 - Remove xdebug support (as we're not generating coverage).
 - Only run CS checks on 5.6.

Additionally, once the above were complete, ran php-cs-fixer without the `--dry-run` flag to fix CS issues.