### PR TITLE
More CS fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,10 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
-      env:
-        - DISABLE_XDEBUG=true
     - php: 5.4
-      env:
-        - DISABLE_XDEBUG=true
     - php: 5.5
-      env:
-        - DISABLE_XDEBUG=true
     - php: 5.6
       env:
-        - DISABLE_XDEBUG=true
         - EXECUTE_CS_CHECK=true
     - php: 7
     - php: hhvm
@@ -29,7 +22,7 @@ matrix:
     - php: hhvm
 
 before_install:
- - if [[ $DISABLE_XDEBUG == 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+ - phpenv config-rm xdebug.ini || return 0
  - composer self-update
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 

--- a/tests/ZendService/Amazon/SimpleDb/OnlineTest.php
+++ b/tests/ZendService/Amazon/SimpleDb/OnlineTest.php
@@ -365,11 +365,11 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             $isLast = $page->isLast();
             if (!$isLast) {
                 // The old isLast() assertTrue failed in full suite runs. Token often
-              // decodes to 'TestsZendServiceAmazonSimpleDbDomain_testPutAttributes'
-              // which no longer exists. Instead of a plain assertTrue, which seemed
-              // to pass only in single-case runs, we'll make sure the token's
-              // presence is worth a negative.
-              $token = $page->getToken();
+                // decodes to 'TestsZendServiceAmazonSimpleDbDomain_testPutAttributes'
+                // which no longer exists. Instead of a plain assertTrue, which seemed
+                // to pass only in single-case runs, we'll make sure the token's
+                // presence is worth a negative.
+                $token = $page->getToken();
                 if ($token) {
                     $tokenDomainName = base64_decode($token);
                     if (false !== strpos($tokenDomainName, $this->_testDomainNamePrefix)) {


### PR DESCRIPTION
- Modified Travis-CI configuration to always attempt to uninstall XDebug, and simply `return 0` (indicating success) on failure (which will happen with PHP 7 and hhvm)
- Fixed more CS issues as reported by @Maks3w