### PR TITLE
Support compatible ZF3 components.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,13 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
       env:
         - EXECUTE_CS_CHECK=true
-    - php: 7
+    - php: 7.0
+    - php: 7.1
     - php: hhvm
   allow_failures:
-    - php: 7
     - php: hhvm
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,12 @@
             "ZendServiceTest\\Amazon\\": "tests/ZendServiceTest/Amazon/"
         }
     },
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "http://packages.zendframework.com/"
-        }
-    ],
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-http": "~2.0",
         "zendframework/zendrest": "~2.0",
-        "zendframework/zend-crypt": "~2.0",
-        "zendframework/zend-json": "~2.0",
+        "zendframework/zend-crypt": "~2.0 || ~3.0",
+        "zendframework/zend-json": "~2.0 || ~3.0",
         "zendframework/zendxml": "~1.0-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "zendframework/zend-http": "~2.0",
         "zendframework/zendrest": "~2.0",
         "zendframework/zend-crypt": "~2.0 || ~3.0",


### PR DESCRIPTION
This PR complements #61 by bringing composer.json a bit more up to date and preventing ZendService_Amazon from locking users into old versions of certain Zend components.