### PR TITLE
Updated Travis CI configuration - PHP 7.2 and 7.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 cache:
@@ -46,17 +44,24 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: hhvm
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.4.0 - TBD
+## 2.3.1 - TBD
 
 ### Added
 
-- Nothing.
+- [#77](https://github.com/zendframework/ZendService_Amazon/pull/77) adds support for PHP 7.3.
 
 ### Deprecated
 


### PR DESCRIPTION
- Added PHP 7.2 and 7.3 builds
- Dropped HHVM builds
- Removed `sudo: false` in `.travis.yml`
